### PR TITLE
Add support for elm-optimize-level-2 output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,16 @@
 const toESModule = js => {
-  const elmExports = js.match(/^_Platform_export\(([^]*)\);}\(this\)\);/m)[1];
+  const elmExports = js.match(
+    /^\s*_Platform_export\(([^]*)\);\n?}\(this\)\);/m
+  )[1];
   return js
-    .replace(/^\(function\(scope\)\{$/m, "// -- $&")
-    .replace(/^'use strict';$/m, "// -- $&")
-    .replace(/function _Platform_export([^]*?)\n\}\n/g, "/*\n$&\n*/")
-    .replace(/function _Platform_mergeExports([^]*?)\n\}\n/g, "/*\n$&\n*/")
-    .replace(/^_Platform_export\(([^]*?)\(this\)\);$/m, '/*\n$&\n*/')
-    .concat("\n")
-    .concat(`export const Elm = ${elmExports};\n`);
+    .replace(/\(function\s*\(scope\)\s*\{$/m, "// -- $&")
+    .replace(/['"]use strict['"];$/m, "// -- $&")
+    .replace(/function _Platform_export([^]*?)\}\n/g, "/*\n$&\n*/")
+    .replace(/function _Platform_mergeExports([^]*?)\}\n\s*}/g, "/*\n$&\n*/")
+    .replace(/^\s*_Platform_export\(([^]*)\);\n?}\(this\)\);/m, "/*\n$&\n*/")
+    .concat(`
+  export const Elm = ${elmExports};
+  `);
 };
 
 module.exports = {toESModule};


### PR DESCRIPTION
I've updated the regex to support both vanilla Elm JS output as well as the JS output of [elm-optimize-level-2](https://github.com/mdgriffith/elm-optimize-level-2).

My end goal is to be able to use `elm-optimize-level-2` with [vite-elm-plugin](https://github.com/mdgriffith/elm-optimize-level-2), however there will need to be additional support added to `vite-elm-plugin` to allow the user to pass `pathToElm` to `node-elm-compiler`. Additionally, `elm-optimize-level-2` isn't currently compatible with `node-elm-compiler` because `node-elm-compiler` automatically runs as `<pathToElm> make <source files>` and `elm-optimize-level-2` runs as `elm-optimize-level-2 <source files>`.